### PR TITLE
feat: making cookie secure again at the proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,35 +70,28 @@ pnpm lint
 
 This will check your code for any style or quality issues and provide feedback.
 
+## Edge Function for Cookie Handling in Vercel Deployment
+
+In this project, we use an **Edge Function** deployed on Vercel to spoof the **Set-Cookie** header from the backend and ensure it is sent correctly in browsers with strict security settings (such as Safari/Chrome on iOS). This helps in setting the `SameSite=Strict` attribute on the cookie, allowing it to be stored properly by the browser, while also ensuring CORS compliance.
+
+### Overview
+1. **Spoofing the `Set-Cookie` Header**: The Edge Function intercepts the response from the backend and modifies the `Set-Cookie` header to set `SameSite=Strict`, ensuring the browser stores the cookie in stricter environments.
+2. **Setting `SameSite=Strict`**: The cookie’s `SameSite` attribute is modified to `Strict`, making sure it behaves correctly in browsers with stricter cookie policies, like those on mobile devices.
+3. **Ensuring CORS Compliance**: The Edge Function also ensures that CORS headers are properly set to avoid issues with cross-origin requests.
+
+### How It Works
+
+- **Production Environment**: In production, the Edge Function runs in Vercel’s Edge Network, where it intercepts responses from the backend. If a `Set-Cookie` header is present, it modifies the cookie to include `SameSite=Strict` and passes it back to the client.
+- **Development Environment**: In the development environment, we bypass the Edge Function and interact directly with the backend, as no modifications are required in this environment.
+
+### Code Flow
+
+1. **Edge Function (Vercel)**: The Edge Function intercepts the response from the backend. If a `Set-Cookie` header is present, it modifies token in the cookie by adding `SameSite=Strict` to ensure the browser handles it appropriately.
+2. **Proxy Handling (`api/proxy.ts`)**: The proxy serves as an intermediary, passing the modified cookies to the user while ensuring that the CORS headers are properly set for compliance.
+3. **Browser Behavior**: With `SameSite=Strict`, browsers like Safari and Chrome on iOS, which have stricter cookie policies, will store the cookie and send it back on subsequent requests through the proxy.
+
+This setup ensures that your authentication cookies are sent and stored properly in all environments, particularly in browsers with stricter default security policies, and ensures proper CORS handling.
+
 ## License
 
 This project is licensed under NOLICENSE - no rights are granted.
-
-## Auth Cookie Note
-
-The application uses an HTTP-only authentication cookie to manage user sessions. As this is a test assignment:
-
-- The cookie is **not marked as secure** (`Secure=false`).
-- The **SameSite** attribute is set to **`None`** (which means it can be accessed across different sites).
-
-While this allows the API to be used in local environments and deployed to my domain, browsers may treat this cookie as a tracking cookie, potentially leading to issues if **tracking** is disabled.
-
-For example, on iOS devices using Chrome and Safari, tracking is disabled by default, which might interfere with the cookie functionality. Please ensure cookies are allowed for this to work properly, especially in these environments.
-
-### Enabling Cookies for Chrome and Safari on iOS
-
-If you're using Chrome or Safari on iOS, follow these steps to allow authentication cookies:
-
-#### **Chrome (iOS)**
-1. Open **Settings** on your iPhone/iPad.
-2. Scroll down and tap **Apps**.
-3. Select **Chrome**.
-4. Find **Allow Cross-Website Tracking** and enable it.
-
-#### **Safari (iOS)**
-1. Open **Settings** on your iPhone/iPad.
-2. Scroll down and tap **Apps**.
-3. Select **Safari**.
-4. Find **Prevent Cross-Site Tracking** and disable it.
-
-Enabling these settings will allow the authentication cookie to function correctly.

--- a/api/proxy.ts
+++ b/api/proxy.ts
@@ -7,6 +7,16 @@ export const config = {
 export default async function handler(req: Request) {
   const origin = req.headers.get("Origin");
   const requestedBy = req.headers.get("X-Requested-By");
+  const cookies = req.headers.get("Cookies");
+
+  // TODO: debugging
+  const authCookie =
+    cookies &&
+    cookies
+      .split(", ")
+      .find((cookie) => cookie.startsWith("fetch-access-token="));
+
+  console.log(`Auth: ${!!authCookie}`);
 
   if (requestedBy !== "dogs-app") {
     return new Response(JSON.stringify({ error: "Invalid Request" }), {
@@ -30,7 +40,6 @@ export default async function handler(req: Request) {
       method: req.method,
       headers: req.headers,
       body: ["GET", "HEAD"].includes(req.method) ? undefined : req.body,
-      credentials: "include",
     });
 
     const responseHeaders = new Headers(backendResponse.headers);

--- a/api/proxy.ts
+++ b/api/proxy.ts
@@ -1,4 +1,8 @@
-import { DOMAINS } from "../src/services/dogApi/consts";
+const DOMAINS = {
+  LOCAL: "http://localhost:5173",
+  API: "https://frontend-take-home-service.fetch.com",
+  DEPLOYMENT: "https://offline-assignment-fetch.vercel.app",
+};
 
 export const config = {
   runtime: "edge",

--- a/api/proxy.ts
+++ b/api/proxy.ts
@@ -33,7 +33,7 @@ export default async function handler(req: Request) {
       },
     );
 
-    const setCookieHeaders: string = backendResponse.headers.get("Set-Cookie");
+    const setCookieHeaders = backendResponse.headers.get("Set-Cookie");
     if (setCookieHeaders) {
       const modifiedCookies = setCookieHeaders
         .split(", ")

--- a/api/proxy.ts
+++ b/api/proxy.ts
@@ -96,10 +96,16 @@ function getCorsHeaders(origin: string | null) {
 
 function makeCookieSecureAgain(cookie: string, origin: string): string {
   const domain = new URL(origin).hostname;
+
+  let expiresMatch = cookie.match(/;\s*expires=([^;]+)/i);
+  let expiresValue = expiresMatch ? `; Expires=${expiresMatch[1]}` : "";
+
   return cookie
     .replace(/;\s*Secure/i, "")
     .replace(/;\s*SameSite=[^;]*/i, "")
     .replace(/;\s*HttpOnly/i, "")
     .replace(/;\s*Domain=[^;]*/i, "")
+    .replace(/;\s*Path=[^;]*/i, "")
+    .concat(expiresValue)
     .concat(`; Secure; HttpOnly; SameSite=Strict; Domain=${domain}; Path=/`);
 }

--- a/config/.env.development
+++ b/config/.env.development
@@ -1,0 +1,1 @@
+VITE_DOG_API_BASE_URL=https://frontend-take-home-service.fetch.com

--- a/config/.env.production
+++ b/config/.env.production
@@ -1,0 +1,1 @@
+VITE_DOG_API_BASE_URL=/api

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import tsEslint from "typescript-eslint";
 import eslintConfigPrettier from "eslint-config-prettier";
 
 export default tsEslint.config(
-  { ignores: ["dist"] },
+  { ignores: ["dist", "api"] },
   {
     extends: [
       js.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@vercel/speed-insights": "^1.2.0",
     "lucide-react": "^0.474.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@vercel/speed-insights':
+        specifier: ^1.2.0
+        version: 1.2.0(react@19.0.0)
       lucide-react:
         specifier: ^0.474.0
         version: 0.474.0(react@19.0.0)
@@ -617,6 +620,29 @@ packages:
   '@typescript-eslint/visitor-keys@8.22.0':
     resolution: {integrity: sha512-AWpYAXnUgvLNabGTy3uBylkgZoosva/miNd1I8Bz3SjotmQPbVqhO4Cczo8AsZ44XVErEBPr/CRSgaj8sG7g0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vercel/speed-insights@1.2.0':
+    resolution: {integrity: sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitejs/plugin-react-swc@3.7.2':
     resolution: {integrity: sha512-y0byko2b2tSVVf5Gpng1eEhX1OvPC7x8yns1Fx8jDzlJp4LS6CMkCPfLw47cjyoMrshQDoQw4qcgjsU9VvlCew==}
@@ -2226,6 +2252,10 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.22.0
       eslint-visitor-keys: 4.2.0
+
+  '@vercel/speed-insights@1.2.0(react@19.0.0)':
+    optionalDependencies:
+      react: 19.0.0
 
   '@vitejs/plugin-react-swc@3.7.2(vite@6.0.11(jiti@2.4.2)(lightningcss@1.29.1))':
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { JSX } from "react";
 import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router";
+import { SpeedInsights } from "@vercel/speed-insights/react";
 import HomePage from "./pages/Home.tsx";
 import LoginPage from "./pages/Login.tsx";
 import ToastContainer from "./components/ToastContainer.tsx";
@@ -25,6 +26,7 @@ const App = () => (
         <Route path="/login" element={<LoginPage />} />
       </Routes>
       <ToastContainer />
+      <SpeedInsights />
     </div>
   </Router>
 );

--- a/src/services/dogApi/consts.ts
+++ b/src/services/dogApi/consts.ts
@@ -1,24 +1,25 @@
-export const DOMAINS = {
-  LOCAL: "http://localhost:5173",
-  API: "https://frontend-take-home-service.fetch.com",
-  DEPLOYMENT: "https://offline-assignment-fetch.vercel.app",
-};
+const withPrefix = (
+  base: string,
+  paths: Record<string, string>,
+): Record<keyof typeof paths, string> =>
+  Object.entries(paths).reduce(
+    (acc, [key, value]) => ({ ...acc, [key]: `${base}${value}` }),
+    {},
+  );
 
 export const PATHS = {
-  BASE: DOMAINS.API,
-  PROXY: `${DOMAINS.DEPLOYMENT}/api`,
-  AUTH: {
-    LOGIN: "/auth/login",
-    LOGOUT: "/auth/logout",
-  },
-  DOGS: {
-    LIST: "/dogs",
-    BREEDS: "/dogs/breeds",
-    SEARCH: "/dogs/search",
-    MATCH: "/dogs/match",
-  },
-  LOCATIONS: {
-    LIST: "/locations",
-    SEARCH: "/locations/search",
-  },
+  AUTH: withPrefix("/auth", {
+    LOGIN: "/login",
+    LOGOUT: "/logout",
+  }),
+  DOGS: withPrefix("/dogs", {
+    LIST: "",
+    BREEDS: "/breeds",
+    SEARCH: "/search",
+    MATCH: "/match",
+  }),
+  LOCATIONS: withPrefix("/locations", {
+    LIST: "",
+    SEARCH: "/search",
+  }),
 };

--- a/src/services/dogApi/consts.ts
+++ b/src/services/dogApi/consts.ts
@@ -1,6 +1,12 @@
-export const URLS = {
-  PROXY: "https://offline-assignment-fetch.vercel.app/api",
-  BASE: "https://frontend-take-home-service.fetch.com",
+export const DOMAINS = {
+  LOCAL: "http://localhost:5173",
+  API: "https://frontend-take-home-service.fetch.com",
+  DEPLOYMENT: "https://offline-assignment-fetch.vercel.app",
+};
+
+export const PATHS = {
+  BASE: DOMAINS.API,
+  PROXY: `${DOMAINS.DEPLOYMENT}/api`,
   AUTH: {
     LOGIN: "/auth/login",
     LOGOUT: "/auth/logout",

--- a/src/services/dogApi/dogApi.ts
+++ b/src/services/dogApi/dogApi.ts
@@ -1,12 +1,12 @@
 import http from "../http.ts";
-import { URLS } from "./consts.ts";
+import { PATHS } from "./consts.ts";
 import type { Dog, SearchDogsResponse, MatchedDog } from "./dtos.ts";
 import type { AuthParams, SearchDogParams } from "./types.ts";
 
 export const auth = ({ email, name }: AuthParams) =>
   http<void>({
     method: "POST",
-    path: URLS.AUTH.LOGIN,
+    path: PATHS.AUTH.LOGIN,
     body: {
       email,
       name,
@@ -16,13 +16,13 @@ export const auth = ({ email, name }: AuthParams) =>
 export const logout = () =>
   http<void>({
     method: "POST",
-    path: URLS.AUTH.LOGOUT,
+    path: PATHS.AUTH.LOGOUT,
   });
 
 export const fetchBreeds = () =>
   http<[string]>({
     method: "GET",
-    path: URLS.DOGS.BREEDS,
+    path: PATHS.DOGS.BREEDS,
   });
 
 const searchAbortController = new AbortController();
@@ -32,13 +32,13 @@ export const searchDogs = async (params: SearchDogParams) => {
 
   const { resultIds, total } = await http<SearchDogsResponse>({
     method: "GET",
-    path: URLS.DOGS.SEARCH,
+    path: PATHS.DOGS.SEARCH,
     params,
     signal: searchAbortController.signal,
   });
   const dogs = await http<[Dog]>({
     method: "POST",
-    path: URLS.DOGS.LIST,
+    path: PATHS.DOGS.LIST,
     body: resultIds,
     signal: searchAbortController.signal,
   });
@@ -49,6 +49,6 @@ export const searchDogs = async (params: SearchDogParams) => {
 export const matchDogs = (dogIds: [string]) =>
   http<MatchedDog>({
     method: "POST",
-    path: URLS.DOGS.MATCH,
+    path: PATHS.DOGS.MATCH,
     body: dogIds,
   });

--- a/src/services/dogApi/dogApi.ts
+++ b/src/services/dogApi/dogApi.ts
@@ -3,10 +3,12 @@ import { PATHS } from "./consts.ts";
 import type { Dog, SearchDogsResponse, MatchedDog } from "./dtos.ts";
 import type { AuthParams, SearchDogParams } from "./types.ts";
 
+const BASE_URL = import.meta.env.VITE_DOG_API_BASE_URL;
+
 export const auth = ({ email, name }: AuthParams) =>
   http<void>({
     method: "POST",
-    path: PATHS.AUTH.LOGIN,
+    url: `${BASE_URL}${PATHS.AUTH.LOGIN}`,
     body: {
       email,
       name,
@@ -16,13 +18,13 @@ export const auth = ({ email, name }: AuthParams) =>
 export const logout = () =>
   http<void>({
     method: "POST",
-    path: PATHS.AUTH.LOGOUT,
+    url: `${BASE_URL}${PATHS.AUTH.LOGOUT}`,
   });
 
 export const fetchBreeds = () =>
   http<[string]>({
     method: "GET",
-    path: PATHS.DOGS.BREEDS,
+    url: `${BASE_URL}${PATHS.DOGS.BREEDS}`,
   });
 
 const searchAbortController = new AbortController();
@@ -32,13 +34,13 @@ export const searchDogs = async (params: SearchDogParams) => {
 
   const { resultIds, total } = await http<SearchDogsResponse>({
     method: "GET",
-    path: PATHS.DOGS.SEARCH,
+    url: `${BASE_URL}${PATHS.DOGS.SEARCH}`,
     params,
     signal: searchAbortController.signal,
   });
   const dogs = await http<[Dog]>({
     method: "POST",
-    path: PATHS.DOGS.LIST,
+    url: `${BASE_URL}${PATHS.DOGS.LIST}`,
     body: resultIds,
     signal: searchAbortController.signal,
   });
@@ -49,6 +51,6 @@ export const searchDogs = async (params: SearchDogParams) => {
 export const matchDogs = (dogIds: [string]) =>
   http<MatchedDog>({
     method: "POST",
-    path: PATHS.DOGS.MATCH,
+    url: `${BASE_URL}${PATHS.DOGS.MATCH}`,
     body: dogIds,
   });

--- a/src/services/http.test.ts
+++ b/src/services/http.test.ts
@@ -1,6 +1,6 @@
 import { vi, expect, it, describe, beforeEach, afterAll } from "vitest";
 import http, { QueryParams, serializeParams } from "./http";
-import { URLS } from "./dogApi/consts.ts";
+import { PATHS } from "./dogApi/consts.ts";
 
 describe("serializeParams", () => {
   it("should serialize a query with simple parameters", () => {
@@ -56,7 +56,7 @@ describe("http", () => {
 
     const result = await http({ path: "/test", method: "GET" });
     expect(result).toEqual(responseData);
-    expect(fetchMock).toHaveBeenCalledWith(`${URLS.PROXY}/test`, {
+    expect(fetchMock).toHaveBeenCalledWith(`${PATHS.PROXY}/test`, {
       credentials: "include",
       method: "GET",
       headers: { "Content-Type": "application/json" },
@@ -98,7 +98,7 @@ describe("http", () => {
     });
 
     expect(result).toEqual(responseData);
-    expect(fetchMock).toHaveBeenCalledWith(`${URLS.PROXY}/test`, {
+    expect(fetchMock).toHaveBeenCalledWith(`${PATHS.PROXY}/test`, {
       credentials: "include",
       method: "POST",
       headers: {

--- a/src/services/http.test.ts
+++ b/src/services/http.test.ts
@@ -1,6 +1,5 @@
 import { vi, expect, it, describe, beforeEach, afterAll } from "vitest";
 import http, { QueryParams, serializeParams } from "./http";
-import { PATHS } from "./dogApi/consts.ts";
 
 describe("serializeParams", () => {
   it("should serialize a query with simple parameters", () => {
@@ -54,9 +53,9 @@ describe("http", () => {
     const responseData = { data: "some data" };
     fetchMock.mockResolvedValueOnce(mockResponse(200, responseData));
 
-    const result = await http({ path: "/test", method: "GET" });
+    const result = await http({ url: "/test", method: "GET" });
     expect(result).toEqual(responseData);
-    expect(fetchMock).toHaveBeenCalledWith(`${PATHS.PROXY}/test`, {
+    expect(fetchMock).toHaveBeenCalledWith(`/test`, {
       credentials: "include",
       method: "GET",
       headers: { "Content-Type": "application/json" },
@@ -66,7 +65,7 @@ describe("http", () => {
   it("should handle 204 No Content response", async () => {
     fetchMock.mockResolvedValueOnce(mockResponse(204, ""));
 
-    const result = await http({ path: "/test", method: "POST" });
+    const result = await http({ url: "/test", method: "POST" });
     expect(result).toBeNull();
   });
 
@@ -75,7 +74,7 @@ describe("http", () => {
     fetchMock.mockResolvedValueOnce(mockResponse(400, errorMessage));
 
     try {
-      await http({ path: "/test", method: "GET" });
+      await http({ url: "/test", method: "GET" });
     } catch (error: unknown) {
       expect((error as Error).message).toBe(
         "Network request failed 400: GET /test - Bad Request",
@@ -91,14 +90,14 @@ describe("http", () => {
     fetchMock.mockResolvedValueOnce(mockResponse(200, responseData));
 
     const result = await http({
-      path: "/test",
+      url: "/test",
       method: "POST",
       body,
       headers: customHeaders,
     });
 
     expect(result).toEqual(responseData);
-    expect(fetchMock).toHaveBeenCalledWith(`${PATHS.PROXY}/test`, {
+    expect(fetchMock).toHaveBeenCalledWith(`/test`, {
       credentials: "include",
       method: "POST",
       headers: {

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -1,4 +1,4 @@
-import { URLS } from "./dogApi/consts.ts";
+import { PATHS } from "./dogApi/consts.ts";
 
 export type SortQueryParam = { field: string; order: "asc" | "desc" };
 export type ArrayQueryParam = string[] | number[];
@@ -57,7 +57,7 @@ async function http<R = undefined>({
     request.headers = { ...request.headers, ...headers };
   }
 
-  let url = `${URLS.PROXY}${path}`;
+  let url = `${PATHS.PROXY}${path}`;
 
   const serializedParams = params && serializeParams(params);
   if (serializedParams) {

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -44,7 +44,11 @@ async function http<R = undefined>({
   const request: RequestInit = {
     credentials: "include",
     method,
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      // fixme: in ideal world there must be hmac or something
+      "X-Requested-By": "dogs-app",
+    },
   };
 
   if (body) {

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -1,5 +1,3 @@
-import { PATHS } from "./dogApi/consts.ts";
-
 export type SortQueryParam = { field: string; order: "asc" | "desc" };
 export type ArrayQueryParam = string[] | number[];
 export type QueryParams = Record<
@@ -8,7 +6,7 @@ export type QueryParams = Record<
 >;
 
 export type HttpServiceParams = {
-  path: string;
+  url: string;
   method: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
   body?: unknown;
   params?: QueryParams;
@@ -37,7 +35,7 @@ export const serializeParams = (params: QueryParams): string => {
 };
 
 async function http<R = undefined>({
-  path,
+  url,
   method,
   body,
   params,
@@ -57,8 +55,6 @@ async function http<R = undefined>({
     request.headers = { ...request.headers, ...headers };
   }
 
-  let url = `${PATHS.PROXY}${path}`;
-
   const serializedParams = params && serializeParams(params);
   if (serializedParams) {
     url += `?${serializedParams}`;
@@ -69,7 +65,7 @@ async function http<R = undefined>({
   if (!response.ok) {
     const errorMessage = await response.text();
     throw new Error(
-      `Network request failed ${response.status}: ${method} ${path} - ${errorMessage}`,
+      `Network request failed ${response.status}: ${method} ${url} - ${errorMessage}`,
     );
   }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_DOG_API_BASE_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -20,5 +20,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts", "api"]
+  "include": ["vite.config.ts"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -20,5 +20,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "api"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import tailwindcss from "@tailwindcss/vite";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  envDir: "config",
   test: {
     environment: "happy-dom",
   },


### PR DESCRIPTION
Trying to fix the issue where browsers believe (by default) auth cookie is for tracking just because it is on the different domain